### PR TITLE
Fix TypeError: moment is not a function

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -23,6 +23,7 @@
             if (!jQuery.fn) jQuery.fn = {};
         }
         var moment = (typeof window != 'undefined' && typeof window.moment != 'undefined') ? window.moment : require('moment');
+        if (typeof moment !== 'function' && moment.hasOwnProperty('default')) moment = moment['default']
         module.exports = factory(moment, jQuery);
     } else {
         // Browser globals


### PR DESCRIPTION
Hey, I have been using Vitejs and Vue3. I was getting the following error while using your npm library.

"TypeError: moment is not a function"

It appears when inserted into the vitejs build, the library tries to use 'moment' however it receives an object instead of moment, the object contains a 'default' property that is the actual moment method.

I've added a check when the package is built via vitejs to check if moment is not a function and whether it has a default property, and if so, override moment with moment.default and continue as usual.

This change fixed the error on our project.

Thanks in advance for this awesome library.